### PR TITLE
Use default retrieval strategy

### DIFF
--- a/src/main/kotlin/di/KoinModule.kt
+++ b/src/main/kotlin/di/KoinModule.kt
@@ -38,7 +38,6 @@ val appModule = module {
         DiscordClient.create(token)
             .gateway()
             .setEnabledIntents(IntentSet.of(Intent.GUILD_PRESENCES))
-            .setEntityRetrievalStrategy(EntityRetrievalStrategy.REST)
             .login()
             .block() ?: error("GatewayDiscordClient.login().block() returned null.")
     }


### PR DESCRIPTION
`EntityRetrievalStrategy.REST` causes `getPresence` to return null when cache isn't ready. Default behaviour gives a sane empty status.