### PR TITLE
Ignore custom status and handle empty presence

### DIFF
--- a/src/main/kotlin/graphics/imagegen.kt
+++ b/src/main/kotlin/graphics/imagegen.kt
@@ -95,7 +95,7 @@ suspend fun generateImage(
     username: String,
     tag: Int,
     avatarUrl: String,
-    status: Status,
+    status: Status?,
     activity: Activity?
 ): BufferedImage = withContext(Dispatchers.Default) {
     // Download avatar
@@ -163,13 +163,15 @@ suspend fun generateImage(
         drawString("#$tag", usernameWidth, USERNAME_TEXT_SIZE + MARGIN)
 
         // Draw status
-        color = Color.WHITE
-        font = fontRegular
-        drawString(
-            "Status: ${status.toString().replace("_", " ").toLowerCase().capitalize()}",
-            0,
-            TEXT_SIZE + USERNAME_TEXT_SIZE + (MARGIN * 4)
-        )
+        if (status != null) {
+            color = Color.WHITE
+            font = fontRegular
+            drawString(
+                "Status: ${status.toString().replace("_", " ").toLowerCase().capitalize()}",
+                0,
+                TEXT_SIZE + USERNAME_TEXT_SIZE + (MARGIN * 4)
+            )
+        }
 
         // Draw activity
         if (activity != null) {

--- a/src/main/kotlin/routes/Banner.kt
+++ b/src/main/kotlin/routes/Banner.kt
@@ -3,6 +3,7 @@ package routes
 import data.tables.Visit
 import discord4j.common.util.Snowflake
 import discord4j.core.GatewayDiscordClient
+import discord4j.core.`object`.presence.Activity
 import discord4j.rest.util.Image
 import generateImage
 import guildId
@@ -14,7 +15,6 @@ import io.ktor.routing.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
@@ -48,14 +48,16 @@ fun Route.horizontalBanner() {
             }
         }
 
-        val presence = member.presence.awaitSingle()
+        val presence = member.presence.awaitSingleOrNull()
+        val activity = presence?.activities
+            ?.firstOrNull { it.type != Activity.Type.CUSTOM }
 
         val image = generateImage(
             member.username,
             member.discriminator.toInt(),
             member.getAvatarUrl(Image.Format.PNG).getOrNull() ?: member.defaultAvatarUrl,
-            presence.status,
-            presence.activity.getOrNull()
+            presence?.status,
+            activity
         )
 
         val bytes = async(Dispatchers.IO) {


### PR DESCRIPTION
Custom presence should no longer appear in the banners, also the route won't crash if the presence cache is not ready yet