### PR TITLE
Better banners + avatar frame

### DIFF
--- a/src/main/kotlin/Constants.kt
+++ b/src/main/kotlin/Constants.kt
@@ -1,3 +1,6 @@
 import discord4j.common.util.Snowflake
 
-val guildId: Snowflake = Snowflake.of(System.getenv("GUILD_ID"))
+object Constants {
+    val guildId: Snowflake = Snowflake.of(System.getenv("GUILD_ID"))
+    val botToken = System.getenv("TOKEN") ?: error("TOKEN environment variable is not set.")
+}

--- a/src/main/kotlin/bot/Bot.kt
+++ b/src/main/kotlin/bot/Bot.kt
@@ -1,0 +1,47 @@
+package bot
+
+import Constants
+import bot.commands.commands
+import discord4j.core.DiscordClient
+import discord4j.core.GatewayDiscordClient
+import discord4j.core.event.ReactiveEventAdapter
+import discord4j.core.event.domain.interaction.SlashCommandEvent
+import discord4j.core.retriever.EntityRetrievalStrategy
+import discord4j.gateway.intent.Intent
+import discord4j.gateway.intent.IntentSet
+import kotlinx.coroutines.reactor.mono
+import org.reactivestreams.Publisher
+import kotlin.concurrent.thread
+
+fun createBot(): GatewayDiscordClient {
+    val restClient = DiscordClient.create(Constants.botToken)
+    val gatewayClient = restClient.gateway()
+        .setEnabledIntents(IntentSet.of(Intent.GUILD_PRESENCES))
+        .setEntityRetrievalStrategy(EntityRetrievalStrategy.REST)
+        .login()
+        .block() ?: error("GatewayDiscordClient.login().block() returned null.")
+
+    val applicationId = restClient.applicationId.block() ?: error("Unable to get application ID")
+
+    commands.values.forEach {
+        restClient.applicationService.createGuildApplicationCommand(
+            applicationId,
+            Constants.guildId.asLong(),
+            it.commandRequest()
+        ).block()
+    }
+
+    gatewayClient.on(object : ReactiveEventAdapter() {
+        override fun onSlashCommand(event: SlashCommandEvent): Publisher<*> {
+            return mono {
+                commands[event.commandName]?.execute(event)
+            }
+        }
+    }).subscribe()
+
+    Runtime.getRuntime().addShutdownHook(thread(false) {
+        gatewayClient.logout().block()
+    })
+
+    return gatewayClient
+}

--- a/src/main/kotlin/bot/commands/Command.kt
+++ b/src/main/kotlin/bot/commands/Command.kt
@@ -1,0 +1,14 @@
+package bot.commands
+
+import discord4j.core.event.domain.interaction.SlashCommandEvent
+import discord4j.discordjson.json.ApplicationCommandRequest
+
+interface Command {
+    val name: String
+    fun commandRequest(): ApplicationCommandRequest
+    suspend fun execute(event: SlashCommandEvent)
+}
+
+val commands : Map<String, Command> = mapOf(
+    EditFrame.name to EditFrame
+)

--- a/src/main/kotlin/bot/commands/EditFrame.kt
+++ b/src/main/kotlin/bot/commands/EditFrame.kt
@@ -1,0 +1,76 @@
+package bot.commands
+
+import data.tables.FramePreferences
+import discord4j.core.event.domain.interaction.SlashCommandEvent
+import discord4j.discordjson.json.ApplicationCommandOptionData
+import discord4j.discordjson.json.ApplicationCommandRequest
+import discord4j.rest.util.ApplicationCommandOptionType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.reactor.awaitSingle
+import org.jetbrains.exposed.sql.insertIgnore
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.sql.update
+import utils.getOrNull
+
+object EditFrame : Command {
+    override val name: String = "avatarframe"
+
+    override fun commandRequest(): ApplicationCommandRequest = ApplicationCommandRequest.builder()
+        .name(name)
+        .description("Set your avatar frame preferences")
+        .addOption(ApplicationCommandOptionData.builder()
+            .name("enabled")
+            .description("Should we show a frame on your banner?")
+            .type(ApplicationCommandOptionType.BOOLEAN.value)
+            .required(false)
+            .build())
+        .addOption(ApplicationCommandOptionData.builder()
+            .name("color")
+            .description("New color of your avatar frame")
+            .type(ApplicationCommandOptionType.STRING.value)
+            .required(false)
+            .build())
+        .build()
+
+    override suspend fun execute(event: SlashCommandEvent) {
+        val userId = event.interaction.user.id.asLong()
+        val colorOption = event.getOption("color").getOrNull()
+        val colorInput = colorOption?.value?.getOrNull()?.asString()
+        val enabled = event.getOption("enabled").getOrNull()?.value?.getOrNull()?.asBoolean()
+
+        val colorCode = try {
+            colorInput
+                ?.removePrefix("#") // Get rid of "#" if it begins with one
+                ?.toInt(16)
+        } catch (e: NumberFormatException) {
+            event.replyEphemeral("Invalid color hex").awaitSingle()
+            return
+        }
+
+        newSuspendedTransaction(Dispatchers.IO) {
+            FramePreferences.insertIgnore {
+                it[this.userId] = userId
+                it[this.color] = colorCode
+                it[this.enabled] = enabled ?: true
+            }
+            FramePreferences.update({ FramePreferences.userId eq userId }) {
+                if (colorCode != null)
+                    it[this.color] = colorCode
+                if (enabled != null)
+                    it[this.enabled] = enabled
+
+                // Reset to defaults if both aguments are null
+                if (colorCode == null && enabled == null) {
+                    it[this.color] = null
+                    it[this.enabled] = true
+                }
+            }
+        }
+
+        if (colorCode == null && enabled == null) {
+            event.replyEphemeral("Avatar frame color rest.").awaitSingle()
+        } else {
+            event.replyEphemeral("Avatar frame updated.").awaitSingle()
+        }
+    }
+}

--- a/src/main/kotlin/data/Database.kt
+++ b/src/main/kotlin/data/Database.kt
@@ -1,0 +1,27 @@
+package data
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.flywaydb.core.Flyway
+import org.jetbrains.exposed.sql.Database
+import kotlin.concurrent.thread
+
+fun createDatabaseConnection() : Database {
+    val databaseUrl = System.getenv("JDBC_DATABASE_URL") ?: error("DATABASE_URL environment variable is not set.")
+    val config = HikariConfig().apply {
+        jdbcUrl = databaseUrl
+    }
+    val ds = HikariDataSource(config)
+    val db =  Database.connect(ds)
+
+    Runtime.getRuntime().addShutdownHook(thread(start = false) {
+        ds.close()
+    })
+
+    // Migrate database
+    Flyway.configure().dataSource(ds).load().apply {
+        migrate()
+    }
+
+    return db
+}

--- a/src/main/kotlin/data/tables/FramePreferences.kt
+++ b/src/main/kotlin/data/tables/FramePreferences.kt
@@ -1,0 +1,25 @@
+package data.tables
+
+import org.jetbrains.exposed.dao.LongEntity
+import org.jetbrains.exposed.dao.LongEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IdTable
+
+/**
+ * User's preferences for avatar frames
+ */
+object FramePreferences : IdTable<Long>("frame_preference") {
+    val userId = long("user_id")
+    val color = integer("color").nullable()
+    val enabled = bool("enabled")
+
+    override val id = userId.entityId()
+    override val primaryKey: PrimaryKey = PrimaryKey(userId)
+}
+
+class FramePreference(id: EntityID<Long>) : LongEntity(id) {
+    companion object: LongEntityClass<FramePreference>(FramePreferences)
+    val userId by FramePreferences.userId
+    val color by FramePreferences.color
+    val enabled by FramePreferences.enabled
+}

--- a/src/main/kotlin/di/KoinModule.kt
+++ b/src/main/kotlin/di/KoinModule.kt
@@ -1,48 +1,14 @@
 package di
 
-import com.zaxxer.hikari.HikariConfig
-import com.zaxxer.hikari.HikariDataSource
-import discord4j.core.DiscordClient
-import discord4j.core.retriever.EntityRetrievalStrategy
-import discord4j.gateway.intent.Intent
-import discord4j.gateway.intent.IntentSet
+import bot.createBot
+import data.createDatabaseConnection
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
-import org.flywaydb.core.Flyway
-import org.jetbrains.exposed.sql.Database
 import org.koin.dsl.module
-import kotlin.concurrent.thread
-
-private fun createDatabaseConnection() : Database {
-    val databaseUrl = System.getenv("JDBC_DATABASE_URL") ?: error("DATABASE_URL environment variable is not set.")
-    val config = HikariConfig().apply {
-        jdbcUrl = databaseUrl
-    }
-    val ds = HikariDataSource(config)
-    val db =  Database.connect(ds)
-
-    Runtime.getRuntime().addShutdownHook(thread(start = false) {
-        ds.close()
-    })
-
-    // Migrate database
-    Flyway.configure().dataSource(ds).load().apply {
-        baseline()
-        migrate()
-    }
-
-    return db
-}
 
 val appModule = module {
     single(createdAtStart = true) {
-        val token = System.getenv("TOKEN") ?: error("TOKEN environment variable is not set.")
-        DiscordClient.create(token)
-            .gateway()
-            .setEnabledIntents(IntentSet.of(Intent.GUILD_PRESENCES))
-            .setEntityRetrievalStrategy(EntityRetrievalStrategy.REST)
-            .login()
-            .block() ?: error("GatewayDiscordClient.login().block() returned null.")
+        createBot()
     }
 
     single(createdAtStart = true) {

--- a/src/main/kotlin/graphics/Shapes.kt
+++ b/src/main/kotlin/graphics/Shapes.kt
@@ -1,0 +1,190 @@
+package graphics
+
+import java.awt.Color
+import java.awt.Graphics2D
+import java.awt.geom.Area
+import java.awt.geom.Ellipse2D
+import java.awt.geom.Rectangle2D
+import java.awt.geom.RoundRectangle2D
+import java.awt.image.BufferedImage
+import java.util.Arrays.fill
+import javax.swing.ImageIcon
+import javax.swing.JLabel
+import javax.swing.JOptionPane
+
+
+interface Drawable {
+    fun draw(g: Graphics2D)
+}
+
+/**
+ * Green dot shown for online status indicator
+ */
+class OnlineStatusIcon(private val size: Int, private val color: Color) : Drawable {
+    override fun draw(g: Graphics2D) {
+        val originalColor = g.color
+        g.color = color
+        g.fillOval(0, 0, size, size)
+        g.color = originalColor
+    }
+}
+
+/**
+ * Moon icon for idle status indicator
+ */
+class IdleStatusIcon(size: Int, private val color: Color) : Drawable {
+    private val shape: Area
+
+    init {
+        val ellipse = Ellipse2D.Float()
+        ellipse.setFrame(0f, 0f, size.toFloat(), size.toFloat())
+        shape = Area(ellipse)
+
+        ellipse.setFrame(
+            -.125f * size,
+            -.125f * size,
+            size.toFloat() * .75f,
+            size.toFloat() * .75f
+        )
+        val outer = Area(ellipse)
+        shape.subtract(outer)
+    }
+
+    override fun draw(g: Graphics2D) {
+        val originalColor = g.color
+        g.color = this.color
+        g.fill(shape)
+        g.color = originalColor
+    }
+}
+
+/**
+ * Ring icon shown for offline status indicator
+ */
+class OfflineStatusIcon(size: Int, private val color: Color) : Drawable {
+    private val shape: Area
+
+    init {
+        val ellipse = Ellipse2D.Float()
+        ellipse.setFrame(0f, 0f, size.toFloat(), size.toFloat())
+        shape = Area(ellipse)
+
+        ellipse.setFrame(
+            .25f * size,
+            .25f * size,
+            size.toFloat() * .5f,
+            size.toFloat() * .5f
+        )
+        val inner = Area(ellipse)
+        shape.subtract(inner)
+    }
+
+    override fun draw(g: Graphics2D) {
+        val originalColor = g.color
+        g.color = color
+        g.fill(shape)
+        g.color = originalColor
+    }
+}
+
+/**
+ * Ring icon shown for "do no disturb" status indicator
+ */
+class DndStatusIcon(size: Int, private val color: Color) : Drawable {
+    private val shape: Area
+
+    init {
+        val ellipse = Ellipse2D.Float()
+        ellipse.setFrame(0f, 0f, size.toFloat(), size.toFloat())
+        shape = Area(ellipse)
+
+        val innerRect = RoundRectangle2D.Float(
+            .125f * size,
+            .375f * size,
+            size.toFloat() * .75f,
+            size.toFloat() * .25f,
+            .25f * size,
+            .25f * size
+        )
+        val inner = Area(innerRect)
+        shape.subtract(inner)
+    }
+
+    override fun draw(g: Graphics2D) {
+        val originalColor = g.color
+        g.color = color
+        g.fill(shape)
+        g.color = originalColor
+    }
+}
+
+class AvatarMask(size: Int) : Drawable {
+
+    private val shape: Area
+
+    init {
+        val ellipse = Ellipse2D.Float(0f, 0f, size.toFloat(), size.toFloat())
+        shape = Area(ellipse)
+
+        val pos = size - (size * .333f)
+
+        val bottomDot = Ellipse2D.Float(pos, pos, size * .333f, size * .333f)
+        shape.subtract(Area(bottomDot))
+    }
+
+    override fun draw(g: Graphics2D) {
+        g.fill(shape)
+    }
+}
+
+/**
+ * The frame on the left of the avatar
+ */
+class AvatarFrame(
+    height: Int,
+    width: Int,
+    margin: Int,
+    cornerRadius: Int,
+) : Drawable {
+
+    private val shape: Area
+
+    init {
+        val rect = RoundRectangle2D.Float(
+            0f,
+            0f,
+            width.toFloat(),
+            height.toFloat(),
+            cornerRadius.toFloat(),
+            cornerRadius.toFloat()
+        )
+        shape = Area(rect)
+
+        // Remove round corners from right side
+        shape.add(Area(
+            Rectangle2D.Float(
+                width - cornerRadius.toFloat(),
+                0f,
+                cornerRadius.toFloat(),
+                height.toFloat()
+            )
+        ))
+
+        // Cut out a circle with size equal to the rectangle's height minus two times the margin
+        val innerCircleSize = height - (margin * 2f)
+        val x = width - innerCircleSize / 2f
+        val y = (height - innerCircleSize) / 2f
+        val innerCircle = Ellipse2D.Float(
+            x,
+            y,
+            innerCircleSize,
+            innerCircleSize
+        )
+        shape.subtract(Area(innerCircle))
+    }
+    override fun draw(g: Graphics2D) {
+        (g.create() as Graphics2D).fill(shape)
+    }
+}
+
+fun Graphics2D.draw(drawable: Drawable) = drawable.draw(this)

--- a/src/main/resources/db/migration/V3__CREATE_TABLE_frame_preference.sql
+++ b/src/main/resources/db/migration/V3__CREATE_TABLE_frame_preference.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS frame_preference(
+       user_id BIGINT PRIMARY KEY,
+       color INTEGER,
+       enabled BOOLEAN NOT NULL
+)


### PR DESCRIPTION
This adds/changes the following:
- A "frame" displayed on the left of avatar, the colour of the frame and it's visibility is configurable through the command `/avatarframe`
- Status indicator icons moved to a new file (`Shapes.kt`) and now are abstracted better with a `Drawable` interface. Also they reassemble Discord's original proportion better.
- The status text uses same colour as the it's corresponding indicator icon.